### PR TITLE
Fix incorrect proxyURL with terragruntURL

### DIFF
--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func main() {
 			installVersion(tgversion, &binPath)
 		/* if terragrunt.hcl file found (IN ADDITION TO A TOML FILE) */
 		case lib.FileExists(TGHACLFile) && checkVersionDefinedHCL(&TGHACLFile) && len(args) == 0:
-			installTGHclFile(&TGHACLFile, binPath, proxyUrl)
+			installTGHclFile(&TGHACLFile, binPath, terragruntURL)
 		/* if terragrunt Version environment variable is set  (IN ADDITION TO A TOML FILE)*/
 		case checkTGEnvExist() && len(args) == 0 && version == "":
 			tgversion := os.Getenv("TG_VERSION")
@@ -158,7 +158,7 @@ func main() {
 		installVersion(tgversion, custBinPath)
 	/* if terragrunt.hcl file found */
 	case lib.FileExists(TGHACLFile) && checkVersionDefinedHCL(&TGHACLFile) && len(args) == 0:
-		installTGHclFile(&TGHACLFile, *custBinPath, proxyUrl)
+		installTGHclFile(&TGHACLFile, *custBinPath, terragruntURL)
 	/* if terragrunt Version environment variable is set*/
 	case checkTGEnvExist() && len(args) == 0:
 		tgversion := os.Getenv("TG_VERSION")


### PR DESCRIPTION
Fixed #133 

I believe this function should not be called with the proxyURL (which is the URL to your cache of Terragrunt versions), instead the Terragrunt mirror URL. Ultimately this is passed through to the download function, which uses the mirrorURL (parameter) to construct the download path for a version. 

This is why we sometimes see 404s (when this particular block/case is encountered) - it's trying to download the binary from this repo! 

Hope the PR Is okay and this makes sense? 