### PR TITLE
Support custom terragrunt release locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ tgswitch
 
 .DS_Store
 
+terragrunt-releases/
+
 docs/vendor/**
 
 docs/.bundle/**

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Required file structure at that endpoint:
 ```
 Note: `tgswitch VERSION` works as expected against a custom endpoint.
 
+See [`scripts/generate-remote.sh`](scripts/generate-remote.sh) for a reference script
+that mirrors terragrunt releases into this layout, ready to upload to your endpoint.
+
 <img style="text-allign:center" src="https://kepler-images.s3.us-east-2.amazonaws.com/warrensbox/tgswitch/tgswitch-banner.png" alt="drawing"/>
 
 

--- a/README.md
+++ b/README.md
@@ -4,21 +4,27 @@
 
 # Terragrunt Switcher 
 
-## Directions for use in region
-- define TGENV_REMOTE to use a remote repo
-```
-export TGENV_REMOTE="https://S3_BUCKET.s3.amazonaws.com/terragrunt-releases
+## Use a custom terragrunt release location
+By default, `tgswitch` reads the version list and downloads binaries from the public
+[terragrunt release page](https://github.com/gruntwork-io/terragrunt/releases) (via a
+[proxy list](https://warrensbox.github.io/terragunt-versions-list/)). To instead serve
+these from your own location, set `TGENV_REMOTE` to any HTTP(S) endpoint that exposes
+the file structure below — an S3 bucket, GCS bucket, internal artifact repository, or a
+plain static file server all work, as long as they're reachable over HTTP(S):
 
 ```
-- File structure required for TGENV_REMOTE 
-``` 
-|_versions.json  
-|_v0.46.1/  
+export TGENV_REMOTE="https://my-endpoint.example.com/terragrunt-releases"
+```
+
+Required file structure at that endpoint:
+```
+|_versions.json
+|_v0.46.1/
   |_terragrunt_linux_amd64
-|_v0.48.0/  
+|_v0.48.0/
   |_terragrunt_linux_amd64
 ```
-Note: tgswitch VERSION works as desired
+Note: `tgswitch VERSION` works as expected against a custom endpoint.
 
 <img style="text-allign:center" src="https://kepler-images.s3.us-east-2.amazonaws.com/warrensbox/tgswitch/tgswitch-banner.png" alt="drawing"/>
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@
 
 # Terragrunt Switcher 
 
+## Directions for use in region
+- define TGENV_REMOTE to use a remote repo
+```
+export TGENV_REMOTE="https://S3_BUCKET.s3.amazonaws.com/terragrunt-releases
+
+```
+- File structure required for TGENV_REMOTE 
+``` 
+|_versions.json  
+|_v0.46.1/  
+  |_terragrunt_linux_amd64
+|_v0.48.0/  
+  |_terragrunt_linux_amd64
+```
+Note: tgswitch VERSION works as desired
+
 <img style="text-allign:center" src="https://kepler-images.s3.us-east-2.amazonaws.com/warrensbox/tgswitch/tgswitch-banner.png" alt="drawing"/>
 
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ export TGENV_REMOTE="https://my-endpoint.example.com/terragrunt-releases"
 Required file structure at that endpoint:
 ```
 |_versions.json
-|_v0.46.1/
+|_v1.1.0/
   |_terragrunt_linux_amd64
-|_v0.48.0/
+|_v1.1.1/
   |_terragrunt_linux_amd64
 ```
 Note: `tgswitch VERSION` works as expected against a custom endpoint.

--- a/main.go
+++ b/main.go
@@ -31,19 +31,30 @@ import (
 )
 
 const (
-	terragruntURL = "https://github.com/gruntwork-io/terragrunt/releases/download/"
-	defaultBin    = "/usr/local/bin/terragrunt" //default bin installation dir
-	rcFilename    = ".tgswitchrc"
-	tgvFilename   = ".terragrunt-version"
-	versionPrefix = "terragrunt_"
-	proxyUrl      = "https://warrensbox.github.io/terragunt-versions-list/index.json"
-	tomlFilename  = ".tgswitch.toml"
-	tgHclFilename = "terragrunt.hcl"
+	defaultTerragruntURL = "https://github.com/gruntwork-io/terragrunt/releases/download/"
+	defaultBin           = "/usr/local/bin/terragrunt" //default bin installation dir
+	rcFilename           = ".tgswitchrc"
+	tgvFilename          = ".terragrunt-version"
+	versionPrefix        = "terragrunt_"
+	defaultProxyURL      = "https://warrensbox.github.io/terragunt-versions-list/index.json"
+	tomlFilename         = ".tgswitch.toml"
+	tgHclFilename        = "terragrunt.hcl"
 )
 
 var version = "0.5.0\n"
 
+// resolveRemoteURLs returns the terragrunt release URL and version-list proxy URL,
+// honoring TGENV_REMOTE for a custom release location when set.
+func resolveRemoteURLs() (terragruntURL, proxyUrl string) {
+	if remote := os.Getenv("TGENV_REMOTE"); remote != "" {
+		return remote, fmt.Sprintf("%s/versions.json", remote)
+	}
+	return defaultTerragruntURL, defaultProxyURL
+}
+
 func main() {
+
+	terragruntURL, proxyUrl := resolveRemoteURLs()
 
 	dir := lib.GetCurrentDirectory()
 	custBinPath := getopt.StringLong("bin", 'b', lib.ConvertExecutableExt(defaultBin), "Custom binary path. Ex: tgswitch -b "+lib.ConvertExecutableExt("/Users/username/bin/terragrunt"))
@@ -110,12 +121,12 @@ func main() {
 		case lib.FileExists(RCFile) && len(args) == 0:
 			lib.ReadingFileMsg(rcFilename)
 			tgversion := lib.RetrieveFileContents(RCFile)
-			installVersion(tgversion, &binPath)
+			installVersion(tgversion, &binPath, terragruntURL, proxyUrl)
 		/* if .terragrunt-version file found (IN ADDITION TO A TOML FILE) */
 		case lib.FileExists(TGVersionFile) && len(args) == 0:
 			lib.ReadingFileMsg(TGVersionFile)
 			tgversion := lib.RetrieveFileContents(TGVersionFile)
-			installVersion(tgversion, &binPath)
+			installVersion(tgversion, &binPath, terragruntURL, proxyUrl)
 		/* if terragrunt.hcl file found (IN ADDITION TO A TOML FILE) */
 		case lib.FileExists(TGHACLFile) && checkVersionDefinedHCL(&TGHACLFile) && len(args) == 0:
 			installTGHclFile(&TGHACLFile, binPath, terragruntURL)
@@ -123,13 +134,13 @@ func main() {
 		case checkTGEnvExist() && len(args) == 0 && version == "":
 			tgversion := os.Getenv("TG_VERSION")
 			fmt.Printf("Terragrunt version environment variable: %s\n", tgversion)
-			installVersion(tgversion, &binPath)
+			installVersion(tgversion, &binPath, terragruntURL, proxyUrl)
 		/* if version is specified in the .toml file */
 		case version != "":
 			lib.Install(version, binPath, terragruntURL)
 		/* show dropdown */
 		default:
-			installFromList(&binPath)
+			installFromList(&binPath, terragruntURL, proxyUrl)
 		}
 
 	case len(args) == 1:
@@ -151,11 +162,11 @@ func main() {
 	case lib.FileExists(RCFile) && len(args) == 0:
 		lib.ReadingFileMsg(rcFilename)
 		tgversion := lib.RetrieveFileContents(RCFile)
-		installVersion(tgversion, custBinPath)
+		installVersion(tgversion, custBinPath, terragruntURL, proxyUrl)
 	case lib.FileExists(TGVersionFile) && len(args) == 0:
 		lib.ReadingFileMsg(TGVersionFile)
 		tgversion := lib.RetrieveFileContents(TGVersionFile)
-		installVersion(tgversion, custBinPath)
+		installVersion(tgversion, custBinPath, terragruntURL, proxyUrl)
 	/* if terragrunt.hcl file found */
 	case lib.FileExists(TGHACLFile) && checkVersionDefinedHCL(&TGHACLFile) && len(args) == 0:
 		installTGHclFile(&TGHACLFile, *custBinPath, terragruntURL)
@@ -163,10 +174,10 @@ func main() {
 	case checkTGEnvExist() && len(args) == 0:
 		tgversion := os.Getenv("TG_VERSION")
 		fmt.Printf("Terragrunt version environment variable: %s\n", tgversion)
-		installVersion(tgversion, custBinPath)
+		installVersion(tgversion, custBinPath, terragruntURL, proxyUrl)
 	/* show dropdown */
 	default:
-		installFromList(custBinPath)
+		installFromList(custBinPath, terragruntURL, proxyUrl)
 		os.Exit(0)
 	}
 
@@ -211,7 +222,7 @@ func GetParamsTOML(binPath string, dir string) (string, string) {
 }
 
 /* installFromList : displays & installs tf version */
-func installFromList(custBinPath *string) {
+func installFromList(custBinPath *string, terragruntURL, proxyUrl string) {
 
 	listOfVersions := lib.GetAppList(proxyUrl)
 	recentVersions, _ := lib.GetRecentVersions()                 //get recent versions from RECENT file
@@ -235,7 +246,7 @@ func installFromList(custBinPath *string) {
 }
 
 // install with provided version as argument
-func installVersion(arg string, custBinPath *string) {
+func installVersion(arg string, custBinPath *string, terragruntURL, proxyUrl string) {
 	if lib.ValidVersionFormat(arg) {
 		requestedVersion := arg
 

--- a/scripts/generate-remote.sh
+++ b/scripts/generate-remote.sh
@@ -10,7 +10,7 @@
 # (S3, GCS, an internal artifact repo, a plain static file server, ...).
 #
 # Usage:
-#   VERSIONS="0.48.0 0.48.1 0.49.0" ./generate-remote.sh [output_dir]
+#   VERSIONS="1.1.0 1.1.1" ./generate-remote.sh [output_dir]
 #
 # Env vars:
 #   VERSIONS  Required. Space-separated terragrunt versions to mirror (no "v" prefix).
@@ -30,7 +30,7 @@ OUT_DIR="${1:-terragrunt-releases}"
 
 if [[ -z "${VERSIONS:-}" ]]; then
   echo "Set VERSIONS to a space-separated list of terragrunt versions to mirror, e.g.:" >&2
-  echo "  VERSIONS=\"0.48.0 0.48.1\" $0" >&2
+  echo "  VERSIONS=\"1.1.0 1.1.1\" $0" >&2
   exit 1
 fi
 

--- a/scripts/generate-remote.sh
+++ b/scripts/generate-remote.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Reference script for building a TGENV_REMOTE-compatible terragrunt mirror.
+#
+# Produces the file layout tgswitch expects when TGENV_REMOTE is set:
+#   <output_dir>/versions.json
+#   <output_dir>/vX.Y.Z/terragrunt_<os>_<arch>
+#
+# Upload the contents of <output_dir> to whatever you point TGENV_REMOTE at
+# (S3, GCS, an internal artifact repo, a plain static file server, ...).
+#
+# Usage:
+#   VERSIONS="0.48.0 0.48.1 0.49.0" ./generate-remote.sh [output_dir]
+#
+# Env vars:
+#   VERSIONS  Required. Space-separated terragrunt versions to mirror (no "v" prefix).
+#   ENDPOINT  Source to download release binaries from. Default: the public
+#             gruntwork-io/terragrunt GitHub releases page.
+#   GOOS      Target OS for the binary name. Default: linux.
+#   GOARCH    Target arch for the binary name. Default: amd64.
+#
+# Requires: curl, jq
+
+set -euo pipefail
+
+ENDPOINT="${ENDPOINT:-https://github.com/gruntwork-io/terragrunt}"
+GOOS="${GOOS:-linux}"
+GOARCH="${GOARCH:-amd64}"
+OUT_DIR="${1:-terragrunt-releases}"
+
+if [[ -z "${VERSIONS:-}" ]]; then
+  echo "Set VERSIONS to a space-separated list of terragrunt versions to mirror, e.g.:" >&2
+  echo "  VERSIONS=\"0.48.0 0.48.1\" $0" >&2
+  exit 1
+fi
+
+download_artifact() {
+  local version="$1" dest="$2"
+  local binary="terragrunt_${GOOS}_${GOARCH}"
+  local url="${ENDPOINT}/releases/download/v${version}/${binary}"
+
+  echo "Downloading terragrunt ${version} (${GOOS}/${GOARCH})..."
+  curl -LsS --fail -o "${dest}/${binary}" "$url"
+}
+
+mkdir -p "$OUT_DIR"
+
+versions_json='{"Versions": []}'
+
+for version in $VERSIONS; do
+  version_dir="${OUT_DIR}/v${version}"
+  mkdir -p "$version_dir"
+  download_artifact "$version" "$version_dir"
+  versions_json=$(jq --arg v "$version" '.Versions += [$v]' <<<"$versions_json")
+done
+
+jq . <<<"$versions_json" > "${OUT_DIR}/versions.json"
+
+echo
+echo "Remote layout ready in ${OUT_DIR}/"
+echo "Upload its contents to your TGENV_REMOTE endpoint."


### PR DESCRIPTION
## Summary

Adds an opt-in `TGENV_REMOTE` environment variable that lets `tgswitch` fetch the version list and terragrunt binaries from a self-hosted location instead of the public GitHub releases page / `warrensbox.github.io` proxy list. Useful for air-gapped environments, internal mirrors, or anywhere pulling directly from GitHub isn't an option.

When unset, behavior is unchanged - same defaults as today.

## Usage

```
export TGENV_REMOTE="https://my-endpoint.example.com/terragrunt-releases"
```

The endpoint must serve:

```
|_versions.json
|_v1.1.0/
  |_terragrunt_linux_amd64
|_v1.1.1/
  |_terragrunt_linux_amd64
```

Any HTTP(S)-reachable static host works (S3, GCS, an internal artifact repo, plain nginx, etc.) - `tgswitch` just issues normal GET requests.

A reference script, `scripts/generate-remote.sh`, is included to mirror a chosen set of terragrunt releases into this layout.

## Changes

- `main.go`: `resolveRemoteURLs()` resolves the release URL and version-list URL once, honoring `TGENV_REMOTE` when set, and threads them through `installFromList`/`installVersion`/`installTGHclFile` instead of relying on package-level constants.
- `scripts/generate-remote.sh`: mirrors a given list of terragrunt versions into the `versions.json` + `vX.Y.Z/` layout above.
- `README.md`: documents the new env var and the reference script.
- `.gitignore`: ignores the script's default output directory.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] Manually ran `scripts/generate-remote.sh` against the real terragrunt GitHub releases and confirmed the output layout and `versions.json` shape match what `tgswitch` parses
- [x] Confirmed default (no `TGENV_REMOTE`) behavior is unchanged
